### PR TITLE
Fixed URL to point to notebook_embed.ipynb

### DIFF
--- a/content/blog/release-0-12-5/contents.lr
+++ b/content/blog/release-0-12-5/contents.lr
@@ -237,7 +237,7 @@ is used for standalone Bokeh plots:
 
 <div class="image"><center><img src="notebook.gif"></center></div>
 
-You can find the notebook above [in the GitHub repository](https://github.com/bokeh/bokeh/blob/0.12.5/examples/howto/server_embed/tornado_embed.py).
+You can find the notebook above [in the GitHub repository](https://github.com/bokeh/bokeh/blob/0.12.5/examples/howto/server_embed/notebook_embed.ipynb).
 
 #### Code of Conduct Adopted
 


### PR DESCRIPTION
Fixed a URL in the blog post filed under:  release-0-12-5/contents.lr.  

Previously, the URL pointed to:  tornado_embed.py.  I changed to point to:  notebook_embed.ipynb